### PR TITLE
Add fix for large request header when using WNA

### DIFF
--- a/oam_config_header_size.py
+++ b/oam_config_header_size.py
@@ -1,0 +1,10 @@
+#From (Doc ID 2038559.1)
+maxHeaderSize="16000"
+
+configTrustedInputs(name="DEFAULT_HEADER",maxSize=maxHeaderSize)
+
+configTrustedInputs(name="DEFAULT_PARAMETER",maxSize=maxHeaderSize)
+
+configTrustedInputs(name="DEFAULT",maxSize=maxHeaderSize)
+
+


### PR DESCRIPTION
Large spnego tokens can create large Authorization headers and break access manager's default maximum size.